### PR TITLE
CakePHP 2.10で、phpunit 4以降に対応

### DIFF
--- a/Test/Case/Controller/TaskContentsController/ViewTest.php
+++ b/Test/Case/Controller/TaskContentsController/ViewTest.php
@@ -391,9 +391,6 @@ class TaskContentsControllerViewTest extends WorkflowControllerViewTest {
  * @return void
  */
 	public function testCommentPost() {
-		// ログイン
-		TestAuthGeneral::login($this, Role::ROOM_ROLE_KEY_GENERAL_USER);
-
 		// コメントPOST
 		$data = [
 			'TaskContent' => [
@@ -406,6 +403,9 @@ class TaskContentsControllerViewTest extends WorkflowControllerViewTest {
 				'ContentComments.ContentComments' => ['comment'],
 			]
 		]);
+
+		// ログイン
+		TestAuthGeneral::login($this, Role::ROOM_ROLE_KEY_GENERAL_USER);
 
 		// ContentCommentsComponent::comment()がコールされる
 		$this->controller->ContentComments->expects($this->once())
@@ -432,9 +432,6 @@ class TaskContentsControllerViewTest extends WorkflowControllerViewTest {
  * @return void
  */
 	public function testCommentPostFail() {
-		// ログイン
-		TestAuthGeneral::login($this, Role::ROOM_ROLE_KEY_GENERAL_USER);
-
 		// コメントPOST
 		$data = [
 			'TaskContent' => [
@@ -447,6 +444,9 @@ class TaskContentsControllerViewTest extends WorkflowControllerViewTest {
 				'ContentComments.ContentComments' => ['comment'],
 			]
 		]);
+
+		// ログイン
+		TestAuthGeneral::login($this, Role::ROOM_ROLE_KEY_GENERAL_USER);
 
 		// ContentCommentsComponent::comment()がコールされる
 		$this->controller->ContentComments->expects($this->once())

--- a/Test/Case/Controller/TaskProgressRateController/EditTest.php
+++ b/Test/Case/Controller/TaskProgressRateController/EditTest.php
@@ -194,7 +194,7 @@ class TaskProgressRateControllerEditTest extends NetCommonsControllerTestCase {
 			'code' => 400,
 			'class' => 'danger',
 			'interval' => 4000,
-			'plugin' => 'NetCommons',
+			//'plugin' => 'NetCommons',
 			'ajax' => true,
 			'error' => '不正なリクエストの可能性があります。',
 		);

--- a/Test/Case/Model/TaskContent/SaveContentTest.php
+++ b/Test/Case/Model/TaskContent/SaveContentTest.php
@@ -165,7 +165,7 @@ class TaskContentSaveContentTest extends WorkflowSaveTest {
 
 		$choicesMock = $this->getMockForModel('Tasks.' . 'TaskCharge', ['setCharges']);
 		$choicesMock->expects($this->any())
-				->method('setChargesAll')
+				->method('setCharges')
 				->will($this->returnValue(false));
 
 		//テスト実行


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/998
・Session->setFlashを使わないようにしたことによる修正
・generateNcの後にログイン処理をするように修正